### PR TITLE
Fix local default branch logic for "git sync"

### DIFF
--- a/docs/contributors/development-workflow.md
+++ b/docs/contributors/development-workflow.md
@@ -62,8 +62,9 @@ get_local_active_branch() {
   git branch --show
 }
 
+# Sourced from: https://stackoverflow.com/a/44750379
 get_local_default_branch() {
-  git config --get init.defaultBranch
+  git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
 }
 
 # Sourced from: https://stackoverflow.com/a/61357104/1277156


### PR DESCRIPTION
Fixed wrong local default branch. The default branch of a Git installation can be different than the default branch of the "origin" repository. E.g. repo: "master", local git: "main"